### PR TITLE
Fix: SASS Compilation Errors and Module System Update

### DIFF
--- a/src/js/utils/responsive.js
+++ b/src/js/utils/responsive.js
@@ -11,7 +11,7 @@ const breakpoints = {
   md: 768,
   lg: 1024,
   xl: 1280,
-  '2xl': 1536
+  xxl: 1536  // Changed from '2xl' to 'xxl'
 };
 
 /**

--- a/src/styles/base/_functions.scss
+++ b/src/styles/base/_functions.scss
@@ -1,23 +1,24 @@
 /* File: src/styles/base/_functions.scss */
 @use 'sass:map';
+@use 'sass:math';
 @use 'variables' as *;
 
 // Remove the unit from a value
 @function strip-unit($value) {
   @if type-of($value) == 'number' and not unitless($value) {
-    @return $value / ($value * 0 + 1);
+    @return math.div($value, ($value * 0 + 1));
   }
   @return $value;
 }
 
 // Calculate rem from px
 @function rem($pixels, $context: 16) {
-  @return ($pixels / $context) * 1rem;
+  @return math.div($pixels, $context) * 1rem;
 }
 
 // Calculate em from px
 @function em($pixels, $context: 16) {
-  @return ($pixels / $context) * 1em;
+  @return math.div($pixels, $context) * 1em;
 }
 
 // Get color with opacity
@@ -53,7 +54,7 @@
   $green: green($color);
   $blue: blue($color);
   
-  $yiq: (($red * 299) + ($green * 587) + ($blue * 114)) / 1000;
+  $yiq: math.div(($red * 299) + ($green * 587) + ($blue * 114), 1000);
   
   @if ($yiq >= 128) {
     @return #000000;

--- a/src/styles/base/_functions.scss
+++ b/src/styles/base/_functions.scss
@@ -1,82 +1,72 @@
 /* File: src/styles/base/_functions.scss */
+@use 'sass:map';
+@use 'variables' as *;
 
 // Remove the unit from a value
 @function strip-unit($value) {
-    @if type-of($value) == 'number' and not unitless($value) {
-      @return $value / ($value * 0 + 1);
-    }
-    @return $value;
+  @if type-of($value) == 'number' and not unitless($value) {
+    @return $value / ($value * 0 + 1);
   }
+  @return $value;
+}
+
+// Calculate rem from px
+@function rem($pixels, $context: 16) {
+  @return ($pixels / $context) * 1rem;
+}
+
+// Calculate em from px
+@function em($pixels, $context: 16) {
+  @return ($pixels / $context) * 1em;
+}
+
+// Get color with opacity
+@function rgba-color($color-name, $opacity: 1) {
+  @if map.has-key($colors, $color-name) {
+    $color: map.get($colors, $color-name);
+    @return rgba($color, $opacity);
+  }
+  @return $color-name;
+}
+
+// Lighten a color by a percentage
+@function color-lighten($color-name, $percentage: 10%) {
+  @if map.has-key($colors, $color-name) {
+    $color: map.get($colors, $color-name);
+    @return lighten($color, $percentage);
+  }
+  @return lighten($color-name, $percentage);
+}
+
+// Darken a color by a percentage
+@function color-darken($color-name, $percentage: 10%) {
+  @if map.has-key($colors, $color-name) {
+    $color: map.get($colors, $color-name);
+    @return darken($color, $percentage);
+  }
+  @return darken($color-name, $percentage);
+}
+
+// Calculate contrast color (black or white) based on background
+@function contrast-color($color) {
+  $red: red($color);
+  $green: green($color);
+  $blue: blue($color);
   
-  // Get the next key in a map
-  @function map-get-next($map, $key) {
-    $keys: map-keys($map);
-    $n: index($keys, $key);
-    
-    @if $n < length($keys) {
-      @return map-get($map, nth($keys, $n + 1));
-    }
-    
-    @return null;
-  }
+  $yiq: (($red * 299) + ($green * 587) + ($blue * 114)) / 1000;
   
-  // Calculate rem from px
-  @function rem($pixels, $context: 16) {
-    @return ($pixels / $context) * 1rem;
+  @if ($yiq >= 128) {
+    @return #000000;
+  } @else {
+    @return #ffffff;
   }
-  
-  // Calculate em from px
-  @function em($pixels, $context: 16) {
-    @return ($pixels / $context) * 1em;
+}
+
+// Get a breakpoint value
+@function breakpoint($breakpoint-name) {
+  @if map.has-key($breakpoints, $breakpoint-name) {
+    @return map.get($breakpoints, $breakpoint-name);
+  } @else {
+    @error "Unknown breakpoint: #{$breakpoint-name}.";
   }
-  
-  // Get color with opacity
-  @function rgba-color($color-name, $opacity: 1) {
-    @if map-has-key($colors, $color-name) {
-      $color: map-get($colors, $color-name);
-      @return rgba($color, $opacity);
-    }
-    @return $color-name;
-  }
-  
-  // Lighten a color by a percentage
-  @function color-lighten($color-name, $percentage: 10%) {
-    @if map-has-key($colors, $color-name) {
-      $color: map-get($colors, $color-name);
-      @return lighten($color, $percentage);
-    }
-    @return lighten($color-name, $percentage);
-  }
-  
-  // Darken a color by a percentage
-  @function color-darken($color-name, $percentage: 10%) {
-    @if map-has-key($colors, $color-name) {
-      $color: map-get($colors, $color-name);
-      @return darken($color, $percentage);
-    }
-    @return darken($color-name, $percentage);
-  }
-  
-  // Calculate contrast color (black or white) based on background
-  @function contrast-color($color) {
-    $red: red($color);
-    $green: green($color);
-    $blue: blue($color);
-    
-    $yiq: (($red * 299) + ($green * 587) + ($blue * 114)) / 1000;
-    
-    @if ($yiq >= 128) {
-      @return #000000;
-    } @else {
-      @return #ffffff;
-    }
-  }
-  
-  // Get a breakpoint value
-  @function breakpoint($breakpoint-name) {
-    @if map-has-key($breakpoints, $breakpoint-name) {
-      @return map-get($breakpoints, $breakpoint-name);
-    } @else {
-      @error "Unknown breakpoint: #{$breakpoint-name}.";
-    }
-  }
+}

--- a/src/styles/base/_grid.scss
+++ b/src/styles/base/_grid.scss
@@ -1,21 +1,23 @@
 /* File: src/styles/base/_grid.scss */
 @use 'variables' as *;
 @use 'mixins' as *;
+@use 'sass:map';
+@use 'sass:math';
 
 // Responsive grid system
 .grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  gap: map-get($spacing, 'md');
+  gap: map.get($spacing, 'md');
   
   @each $breakpoint, $value in $breakpoints {
     @include breakpoint($breakpoint) {
       &.#{$breakpoint}-gap-none { gap: 0; }
-      &.#{$breakpoint}-gap-xs { gap: map-get($spacing, 'xs'); }
-      &.#{$breakpoint}-gap-sm { gap: map-get($spacing, 'sm'); }
-      &.#{$breakpoint}-gap-md { gap: map-get($spacing, 'md'); }
-      &.#{$breakpoint}-gap-lg { gap: map-get($spacing, 'lg'); }
-      &.#{$breakpoint}-gap-xl { gap: map-get($spacing, 'xl'); }
+      &.#{$breakpoint}-gap-xs { gap: map.get($spacing, 'xs'); }
+      &.#{$breakpoint}-gap-sm { gap: map.get($spacing, 'sm'); }
+      &.#{$breakpoint}-gap-md { gap: map.get($spacing, 'md'); }
+      &.#{$breakpoint}-gap-lg { gap: map.get($spacing, 'lg'); }
+      &.#{$breakpoint}-gap-xl { gap: map.get($spacing, 'xl'); }
     }
   }
 }
@@ -60,10 +62,10 @@
 .flex-grid {
   display: flex;
   flex-wrap: wrap;
-  margin: -#{map-get($spacing, 'sm')};
+  margin: -#{map.get($spacing, 'sm')};
   
   > * {
-    padding: map-get($spacing, 'sm');
+    padding: map.get($spacing, 'sm');
   }
   
   &.no-gutters {
@@ -85,8 +87,8 @@
   @include breakpoint($breakpoint) {
     @for $i from 1 through 12 {
       .#{$breakpoint}\:flex-col-#{$i} {
-        flex: 0 0 percentage($i / 12);
-        max-width: percentage($i / 12);
+        flex: 0 0 math.percentage(math.div($i, 12));
+        max-width: math.percentage(math.div($i, 12));
       }
     }
   }
@@ -135,7 +137,7 @@
 }
 
 // Nested grid mixin for component-specific grids
-@mixin nested-grid($columns: 12, $gap: map-get($spacing, 'md')) {
+@mixin nested-grid($columns: 12, $gap: map.get($spacing, 'md')) {
   display: grid;
   grid-template-columns: repeat($columns, 1fr);
   gap: $gap;

--- a/src/styles/base/_layout.scss
+++ b/src/styles/base/_layout.scss
@@ -1,6 +1,7 @@
 /* File: src/styles/base/_layout.scss */
 @use 'variables' as *;
 @use 'mixins' as *;
+@use 'sass:map';
 
 body {
   @include bg-color('bg');
@@ -16,18 +17,18 @@ body {
 
 main {
   flex: 1;
-  padding: map-get($spacing, '2xl') 0;
+  padding: map.get($spacing, '2xl') 0;
   
   @include breakpoint('md') {
-    padding: map-get($spacing, '3xl') 0;
+    padding: map.get($spacing, '3xl') 0;
   }
 }
 
 section {
-  margin-bottom: map-get($spacing, '3xl');
+  margin-bottom: map.get($spacing, '3xl');
   
   @include breakpoint('md') {
-    margin-bottom: map-get($spacing, '4xl');
+    margin-bottom: map.get($spacing, '4xl');
   }
   
   &:last-child {
@@ -38,7 +39,7 @@ section {
 .section-title {
   display: flex;
   align-items: center;
-  margin-bottom: map-get($spacing, 'xl');
+  margin-bottom: map.get($spacing, 'xl');
   
   &::after {
     content: "";
@@ -46,40 +47,40 @@ section {
     height: 1px;
     width: 100%;
     max-width: 300px;
-    margin-left: map-get($spacing, 'md');
-    background-color: rgba(map-get($colors, 'text-light'), 0.2);
+    margin-left: map.get($spacing, 'md');
+    background-color: rgba(map.get($colors, 'text-light'), 0.2);
   }
 }
 
 // Grid layouts
 .grid-2 {
-  @include grid(1, map-get($spacing, 'lg'));
+  @include grid(1, map.get($spacing, 'lg'));
   
   @include breakpoint('md') {
-    @include grid(2, map-get($spacing, 'lg'));
+    @include grid(2, map.get($spacing, 'lg'));
   }
 }
 
 .grid-3 {
-  @include grid(1, map-get($spacing, 'lg'));
+  @include grid(1, map.get($spacing, 'lg'));
   
   @include breakpoint('md') {
-    @include grid(2, map-get($spacing, 'lg'));
+    @include grid(2, map.get($spacing, 'lg'));
   }
   
   @include breakpoint('lg') {
-    @include grid(3, map-get($spacing, 'lg'));
+    @include grid(3, map.get($spacing, 'lg'));
   }
 }
 
 .grid-4 {
-  @include grid(1, map-get($spacing, 'lg'));
+  @include grid(1, map.get($spacing, 'lg'));
   
   @include breakpoint('sm') {
-    @include grid(2, map-get($spacing, 'lg'));
+    @include grid(2, map.get($spacing, 'lg'));
   }
   
   @include breakpoint('lg') {
-    @include grid(4, map-get($spacing, 'lg'));
+    @include grid(4, map.get($spacing, 'lg'));
   }
 }

--- a/src/styles/base/_mixins.scss
+++ b/src/styles/base/_mixins.scss
@@ -1,15 +1,28 @@
 /* File: src/styles/base/_mixins.scss */
 @use "variables" as *;
+@use "sass:map";
 
 // Media Queries
-@mixin breakpoint($point) {
-  @if map-has-key($breakpoints, $point) {
-    @media (min-width: map-get($breakpoints, $point)) {
-      @content;
+@mixin breakpoint($point, $direction: 'min') {
+  @if $direction == 'max' {
+    @if map.has-key($breakpoints, $point) {
+      @media (max-width: (map.get($breakpoints, $point) - 1px)) {
+        @content;
+      }
+    } @else {
+      @media (max-width: $point) {
+        @content;
+      }
     }
   } @else {
-    @media (min-width: $point) {
-      @content;
+    @if map.has-key($breakpoints, $point) {
+      @media (min-width: map.get($breakpoints, $point)) {
+        @content;
+      }
+    } @else {
+      @media (min-width: $point) {
+        @content;
+      }
     }
   }
 }
@@ -24,7 +37,7 @@
 }
 
 // Grid utilities
-@mixin grid($columns: 1, $gap: map-get($spacing, 'md')) {
+@mixin grid($columns: 1, $gap: map.get($spacing, 'md')) {
   display: grid;
   grid-template-columns: repeat($columns, 1fr);
   gap: $gap;
@@ -32,8 +45,8 @@
 
 // Typography
 @mixin font-size($size, $line-height: 1.5) {
-  @if map-has-key($font-sizes, $size) {
-    font-size: map-get($font-sizes, $size);
+  @if map.has-key($font-sizes, $size) {
+    font-size: map.get($font-sizes, $size);
   } @else {
     font-size: $size;
   }
@@ -41,12 +54,12 @@
 }
 
 // Transitions
-@mixin transition($property: all, $speed: map-get($transition-speed, 'normal'), $ease: $transition-ease) {
+@mixin transition($property: all, $speed: map.get($transition-speed, 'normal'), $ease: $transition-ease) {
   transition: $property $speed $ease;
 }
 
 // Container
-@mixin container($max-width: 1200px, $padding: map-get($spacing, 'md')) {
+@mixin container($max-width: 1200px, $padding: map.get($spacing, 'md')) {
   width: 100%;
   max-width: $max-width;
   margin-left: auto;
@@ -84,16 +97,16 @@
 
 // Color utilities
 @mixin color($color-name, $opacity: 1) {
-  @if map-has-key($colors, $color-name) {
-    color: rgba(map-get($colors, $color-name), $opacity);
+  @if map.has-key($colors, $color-name) {
+    color: rgba(map.get($colors, $color-name), $opacity);
   } @else {
     color: $color-name;
   }
 }
 
 @mixin bg-color($color-name, $opacity: 1) {
-  @if map-has-key($colors, $color-name) {
-    background-color: rgba(map-get($colors, $color-name), $opacity);
+  @if map.has-key($colors, $color-name) {
+    background-color: rgba(map.get($colors, $color-name), $opacity);
   } @else {
     background-color: $color-name;
   }
@@ -101,8 +114,8 @@
 
 // Focus styles
 @mixin focus-ring($color: 'secondary', $offset: 2px) {
-  @if map-has-key($colors, $color) {
-    $focus-color: map-get($colors, $color);
+  @if map.has-key($colors, $color) {
+    $focus-color: map.get($colors, $color);
     &:focus-visible {
       outline: 2px solid $focus-color;
       outline-offset: $offset;

--- a/src/styles/base/_responsive.scss
+++ b/src/styles/base/_responsive.scss
@@ -1,15 +1,14 @@
 /* File: src/styles/base/_responsive.scss */
 @use 'variables' as *;
 @use 'mixins' as *;
-
-// Import the strip-unit function from _functions.scss before using it
-@use 'functions' as *;
+@use 'sass:map';
+@use 'sass:math';
 
 // Container width constraints for different viewport sizes
 .container {
   width: 100%;
   margin: 0 auto;
-  padding: 0 map-get($spacing, 'lg');
+  padding: 0 map.get($spacing, 'lg');
   
   @include breakpoint('sm') {
     max-width: 540px;
@@ -27,7 +26,7 @@
     max-width: 1140px;
   }
   
-  @include breakpoint('2xl') {
+  @include breakpoint('xxl') {
     max-width: 1320px;
   }
 }
@@ -110,28 +109,9 @@
       display: none !important;
     }
   }
-  
-  .show-for-#{$breakpoint}-only {
-    display: none !important;
-    
-    @media (min-width: $value) and (max-width: (map-get-next($breakpoints, $breakpoint) - 1px)) {
-      display: block !important;
-    }
-  }
 }
 
 // Helper functions
 @function strip-unit($value) {
   @return $value / ($value * 0 + 1);
-}
-
-@function map-get-next($map, $key) {
-  $keys: map-keys($map);
-  $n: index($keys, $key);
-  
-  @if $n < length($keys) {
-    @return map-get($map, nth($keys, $n + 1));
-  }
-  
-  @return null;
 }

--- a/src/styles/base/_responsive.scss
+++ b/src/styles/base/_responsive.scss
@@ -33,10 +33,10 @@
 
 // Fluid typography system
 @mixin fluid-type($min-vw, $max-vw, $min-font-size, $max-font-size) {
-  $u1: unit($min-vw);
-  $u2: unit($max-vw);
-  $u3: unit($min-font-size);
-  $u4: unit($max-font-size);
+  $u1: math.unit($min-vw);
+  $u2: math.unit($max-vw);
+  $u3: math.unit($min-font-size);
+  $u4: math.unit($max-font-size);
 
   @if $u1 == $u2 and $u1 == $u3 and $u1 == $u4 {
     & {
@@ -113,5 +113,5 @@
 
 // Helper functions
 @function strip-unit($value) {
-  @return $value / ($value * 0 + 1);
+  @return math.div($value, ($value * 0 + 1));
 }

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -1,125 +1,134 @@
-/* File: src/styles/base/_typography.scss */
-@use 'variables' as *;
-@use 'mixins' as *;
+/* File: src/styles/utils/_responsive-typography.scss */
+@use '../base/variables' as *;
+@use '../base/mixins' as *;
+@use '../base/responsive' as responsive;
+@use 'sass:map';
 
-body {
-  font-family: map-get($fonts, 'primary');
-  @include font-size('base');
-  @include color('text');
-}
-
-h1, h2, h3, h4, h5, h6 {
-  margin-bottom: map-get($spacing, 'md');
-  @include color('text-light');
-  font-weight: map-get($font-weights, 'bold');
-  line-height: 1.2;
-}
-
-h1 {
-  @include font-size('5xl');
-  letter-spacing: -0.025em;
-  
-  @include breakpoint('md') {
-    @include font-size('6xl');
+// Responsive font size utilities
+@each $breakpoint, $breakpoint-value in $breakpoints {
+  @include breakpoint($breakpoint) {
+    @each $size-name, $size-value in $font-sizes {
+      .#{$breakpoint}\:text-#{$size-name} {
+        font-size: $size-value !important;
+      }
+    }
+    
+    // Responsive font weights
+    @each $weight-name, $weight-value in $font-weights {
+      .#{$breakpoint}\:font-#{$weight-name} {
+        font-weight: $weight-value !important;
+      }
+    }
+    
+    // Responsive text alignment
+    .#{$breakpoint}\:text-left {
+      text-align: left !important;
+    }
+    
+    .#{$breakpoint}\:text-center {
+      text-align: center !important;
+    }
+    
+    .#{$breakpoint}\:text-right {
+      text-align: right !important;
+    }
+    
+    .#{$breakpoint}\:text-justify {
+      text-align: justify !important;
+    }
+    
+    // Responsive text transforms
+    .#{$breakpoint}\:text-lowercase {
+      text-transform: lowercase !important;
+    }
+    
+    .#{$breakpoint}\:text-uppercase {
+      text-transform: uppercase !important;
+    }
+    
+    .#{$breakpoint}\:text-capitalize {
+      text-transform: capitalize !important;
+    }
+    
+    // Responsive text wrapping
+    .#{$breakpoint}\:text-wrap {
+      white-space: normal !important;
+    }
+    
+    .#{$breakpoint}\:text-nowrap {
+      white-space: nowrap !important;
+    }
+    
+    // Responsive line heights
+    .#{$breakpoint}\:leading-none {
+      line-height: 1 !important;
+    }
+    
+    .#{$breakpoint}\:leading-tight {
+      line-height: 1.25 !important;
+    }
+    
+    .#{$breakpoint}\:leading-snug {
+      line-height: 1.375 !important;
+    }
+    
+    .#{$breakpoint}\:leading-normal {
+      line-height: 1.5 !important;
+    }
+    
+    .#{$breakpoint}\:leading-relaxed {
+      line-height: 1.625 !important;
+    }
+    
+    .#{$breakpoint}\:leading-loose {
+      line-height: 2 !important;
+    }
   }
+}
+
+// Fluid typography for headings
+h1 {
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, '3xl'), map.get($font-sizes, '6xl'));
 }
 
 h2 {
-  @include font-size('3xl');
-  
-  @include breakpoint('md') {
-    @include font-size('4xl');
-  }
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, '2xl'), map.get($font-sizes, '4xl'));
 }
 
 h3 {
-  @include font-size('2xl');
-  
-  @include breakpoint('md') {
-    @include font-size('3xl');
-  }
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'xl'), map.get($font-sizes, '3xl'));
 }
 
 h4 {
-  @include font-size('xl');
-  
-  @include breakpoint('md') {
-    @include font-size('2xl');
-  }
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'lg'), map.get($font-sizes, '2xl'));
 }
 
 h5 {
-  @include font-size('lg');
-  
-  @include breakpoint('md') {
-    @include font-size('xl');
-  }
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'base'), map.get($font-sizes, 'xl'));
 }
 
 h6 {
-  @include font-size('base');
-  
-  @include breakpoint('md') {
-    @include font-size('lg');
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'sm'), map.get($font-sizes, 'lg'));
+}
+
+// Line clamp utilities for text truncation
+@for $i from 1 through 5 {
+  .line-clamp-#{$i} {
+    display: -webkit-box;
+    -webkit-line-clamp: $i;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 }
 
-p {
-  margin-bottom: map-get($spacing, 'md');
-  @include font-size('base');
-  
-  &:last-child {
-    margin-bottom: 0;
-  }
+// Helper classes for text overflow
+.text-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-a {
-  @include color('secondary');
-  @include transition;
-  
-  &:hover {
-    text-decoration: underline;
-  }
-  
-  &:focus {
-    @include focus-ring;
-  }
-}
-
-.small-text {
-  @include font-size('sm');
-}
-
-.large-text {
-  @include font-size('lg');
-}
-
-.mono {
-  font-family: map-get($fonts, 'mono');
-}
-
-.text-center {
-  text-align: center;
-}
-
-.text-right {
-  text-align: right;
-}
-
-.text-left {
-  text-align: left;
-}
-
-// Text colors
-@each $name, $color in $colors {
-  .text-#{$name} {
-    @include color($name);
-  }
-}
-
-// Font weights
-@each $name, $weight in $font-weights {
-  .font-#{$name} {
-    font-weight: $weight;
-  }
+.text-break {
+  word-break: break-word;
+  overflow-wrap: break-word;
 }

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -1,92 +1,29 @@
-/* File: src/styles/utils/_responsive-typography.scss */
-@use '../base/variables' as *;
-@use '../base/mixins' as *;
-@use '../base/responsive' as responsive;
+/* File: src/styles/base/_typography.scss */
+@use 'variables' as *;
+@use 'mixins' as *;
+@use 'responsive' as responsive;
 @use 'sass:map';
 
-// Responsive font size utilities
-@each $breakpoint, $breakpoint-value in $breakpoints {
-  @include breakpoint($breakpoint) {
-    @each $size-name, $size-value in $font-sizes {
-      .#{$breakpoint}\:text-#{$size-name} {
-        font-size: $size-value !important;
-      }
-    }
-    
-    // Responsive font weights
-    @each $weight-name, $weight-value in $font-weights {
-      .#{$breakpoint}\:font-#{$weight-name} {
-        font-weight: $weight-value !important;
-      }
-    }
-    
-    // Responsive text alignment
-    .#{$breakpoint}\:text-left {
-      text-align: left !important;
-    }
-    
-    .#{$breakpoint}\:text-center {
-      text-align: center !important;
-    }
-    
-    .#{$breakpoint}\:text-right {
-      text-align: right !important;
-    }
-    
-    .#{$breakpoint}\:text-justify {
-      text-align: justify !important;
-    }
-    
-    // Responsive text transforms
-    .#{$breakpoint}\:text-lowercase {
-      text-transform: lowercase !important;
-    }
-    
-    .#{$breakpoint}\:text-uppercase {
-      text-transform: uppercase !important;
-    }
-    
-    .#{$breakpoint}\:text-capitalize {
-      text-transform: capitalize !important;
-    }
-    
-    // Responsive text wrapping
-    .#{$breakpoint}\:text-wrap {
-      white-space: normal !important;
-    }
-    
-    .#{$breakpoint}\:text-nowrap {
-      white-space: nowrap !important;
-    }
-    
-    // Responsive line heights
-    .#{$breakpoint}\:leading-none {
-      line-height: 1 !important;
-    }
-    
-    .#{$breakpoint}\:leading-tight {
-      line-height: 1.25 !important;
-    }
-    
-    .#{$breakpoint}\:leading-snug {
-      line-height: 1.375 !important;
-    }
-    
-    .#{$breakpoint}\:leading-normal {
-      line-height: 1.5 !important;
-    }
-    
-    .#{$breakpoint}\:leading-relaxed {
-      line-height: 1.625 !important;
-    }
-    
-    .#{$breakpoint}\:leading-loose {
-      line-height: 2 !important;
-    }
-  }
+// Base typography
+body {
+  font-family: map.get($fonts, 'primary');
+  font-size: map.get($font-sizes, 'base');
+  line-height: 1.5;
+  color: map.get($colors, 'text');
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-// Fluid typography for headings
+// Headings
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  margin-bottom: map.get($spacing, 'md');
+  font-weight: map.get($font-weights, 'bold');
+  line-height: 1.2;
+  color: map.get($colors, 'text-light');
+}
+
+// Apply fluid typography to headings
 h1 {
   @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, '3xl'), map.get($font-sizes, '6xl'));
 }
@@ -111,24 +48,130 @@ h6 {
   @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'sm'), map.get($font-sizes, 'lg'));
 }
 
-// Line clamp utilities for text truncation
-@for $i from 1 through 5 {
-  .line-clamp-#{$i} {
-    display: -webkit-box;
-    -webkit-line-clamp: $i;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+// Links
+a {
+  color: map.get($colors, 'secondary');
+  text-decoration: none;
+  transition: color 0.3s ease;
+  
+  &:hover {
+    color: rgba(map.get($colors, 'secondary'), 0.8);
+    text-decoration: underline;
   }
 }
 
-// Helper classes for text overflow
+// Paragraphs
+p {
+  margin-top: 0;
+  margin-bottom: map.get($spacing, 'md');
+  
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+// Lists
+ul, ol {
+  margin-top: 0;
+  margin-bottom: map.get($spacing, 'md');
+  padding-left: map.get($spacing, 'lg');
+  
+  li {
+    margin-bottom: map.get($spacing, 'xs');
+  }
+}
+
+// Small text
+small, .text-small {
+  font-size: map.get($font-sizes, 'sm');
+}
+
+// Large text
+.text-lg {
+  font-size: map.get($font-sizes, 'lg');
+}
+
+.text-xl {
+  font-size: map.get($font-sizes, 'xl');
+}
+
+.text-2xl {
+  font-size: map.get($font-sizes, '2xl');
+}
+
+// Text alignment
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+// Font weights
+.font-light {
+  font-weight: map.get($font-weights, 'light');
+}
+
+.font-normal {
+  font-weight: map.get($font-weights, 'regular');
+}
+
+.font-medium {
+  font-weight: map.get($font-weights, 'medium');
+}
+
+.font-semibold {
+  font-weight: map.get($font-weights, 'semibold');
+}
+
+.font-bold {
+  font-weight: map.get($font-weights, 'bold');
+}
+
+// Text colors
+.text-primary {
+  color: map.get($colors, 'primary');
+}
+
+.text-secondary {
+  color: map.get($colors, 'secondary');
+}
+
+.text-light {
+  color: map.get($colors, 'text-light');
+}
+
+.text-muted {
+  color: rgba(map.get($colors, 'text'), 0.7);
+}
+
+// Monospaced text
+.mono {
+  font-family: map.get($fonts, 'mono');
+}
+
+// Helper classes
 .text-truncate {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.text-break {
-  word-break: break-word;
-  overflow-wrap: break-word;
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -62,7 +62,7 @@ $breakpoints: (
   'md': 768px,
   'lg': 1024px,
   'xl': 1280px,
-  '2xl': 1536px
+  'xxl': 1536px  // Changed from '2xl' to 'xxl'
 );
 
 // Z-index levels

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -1,15 +1,16 @@
 /* File: src/styles/components/_buttons.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 .btn {
   display: inline-block;
-  padding: map-get($spacing, 'sm') map-get($spacing, 'lg');
-  font-weight: map-get($font-weights, 'medium');
+  padding: map.get($spacing, 'sm') map.get($spacing, 'lg');
+  font-weight: map.get($font-weights, 'medium');
   text-align: center;
   border: 1px solid transparent;
   @include font-size('base');
-  border-radius: map-get($border-radius, 'md');
+  border-radius: map.get($border-radius, 'md');
   @include transition;
   cursor: pointer;
   
@@ -35,7 +36,7 @@
   // Secondary/Outline button
   &-outline {
     background-color: transparent;
-    border-color: map-get($colors, 'secondary');
+    border-color: map.get($colors, 'secondary');
     @include color('secondary');
     
     &:hover {
@@ -46,7 +47,7 @@
   // Text button (no background)
   &-text {
     background-color: transparent;
-    padding: map-get($spacing, 'xs') map-get($spacing, 'sm');
+    padding: map.get($spacing, 'xs') map.get($spacing, 'sm');
     @include color('secondary');
     
     &:hover {
@@ -62,7 +63,7 @@
     width: 2.5rem;
     height: 2.5rem;
     padding: 0;
-    border-radius: map-get($border-radius, 'full');
+    border-radius: map.get($border-radius, 'full');
     
     svg {
       width: 1.25rem;
@@ -72,12 +73,12 @@
   
   // Button sizes
   &-sm {
-    padding: map-get($spacing, 'xs') map-get($spacing, 'md');
+    padding: map.get($spacing, 'xs') map.get($spacing, 'md');
     @include font-size('sm');
   }
   
   &-lg {
-    padding: map-get($spacing, 'md') map-get($spacing, 'xl');
+    padding: map.get($spacing, 'md') map.get($spacing, 'xl');
     @include font-size('lg');
   }
 }
@@ -90,13 +91,13 @@
     border-radius: 0;
     
     &:first-child {
-      border-top-left-radius: map-get($border-radius, 'md');
-      border-bottom-left-radius: map-get($border-radius, 'md');
+      border-top-left-radius: map.get($border-radius, 'md');
+      border-bottom-left-radius: map.get($border-radius, 'md');
     }
     
     &:last-child {
-      border-top-right-radius: map-get($border-radius, 'md');
-      border-bottom-right-radius: map-get($border-radius, 'md');
+      border-top-right-radius: map.get($border-radius, 'md');
+      border-bottom-right-radius: map.get($border-radius, 'md');
     }
     
     &:not(:last-child) {

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -1,6 +1,7 @@
 /* File: src/styles/components/_header.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 .header {
   position: fixed;
@@ -8,8 +9,8 @@
   left: 0;
   right: 0;
   width: 100%;
-  z-index: map-get($z-index, 'fixed');
-  background-color: rgba(map-get($colors, 'bg'), 0.85);
+  z-index: map.get($z-index, 'fixed');
+  background-color: rgba(map.get($colors, 'bg'), 0.85);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -29,10 +30,10 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: map-get($spacing, 'md') 0;
+    padding: map.get($spacing, 'md') 0;
     
     @include breakpoint('md') {
-      padding: map-get($spacing, 'lg') 0;
+      padding: map.get($spacing, 'lg') 0;
     }
   }
   
@@ -40,21 +41,21 @@
   &__logo {
     display: flex;
     align-items: center;
-    color: map-get($colors, 'secondary');
-    font-weight: map-get($font-weights, 'bold');
-    font-family: map-get($fonts, 'mono');
+    color: map.get($colors, 'secondary');
+    font-weight: map.get($font-weights, 'bold');
+    font-family: map.get($fonts, 'mono');
     font-size: 1.5rem;
     text-decoration: none;
     
     svg {
       height: 2rem;
       width: 2rem;
-      margin-right: map-get($spacing, 'sm');
+      margin-right: map.get($spacing, 'sm');
     }
     
     &:hover {
       text-decoration: none;
-      color: map-get($colors, 'secondary');
+      color: map.get($colors, 'secondary');
     }
   }
   
@@ -68,14 +69,14 @@
       width: 75vw;
       max-width: 400px;
       height: 100vh;
-      background-color: map-get($colors, 'bg-light');
-      padding: map-get($spacing, '3xl') map-get($spacing, 'xl');
+      background-color: map.get($colors, 'bg-light');
+      padding: map.get($spacing, '3xl') map.get($spacing, 'xl');
       transform: translateX(100%);
       transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
       display: flex;
       justify-content: center;
       flex-direction: column;
-      z-index: map-get($z-index, 'modal');
+      z-index: map.get($z-index, 'modal');
       box-shadow: -10px 0 30px -15px rgba(0, 0, 0, 0.5);
       
       &.is-open {
@@ -105,12 +106,12 @@
   
   // Navigation item
   &__nav-item {
-    margin: 0 map-get($spacing, 'md');
+    margin: 0 map.get($spacing, 'md');
     position: relative;
     counter-increment: item;
     
     @include breakpoint('max', 'md') {
-      margin: map-get($spacing, 'md') 0;
+      margin: map.get($spacing, 'md') 0;
       width: 100%;
     }
   }
@@ -118,38 +119,38 @@
   // Navigation link
   &__nav-link {
     display: inline-block;
-    padding: map-get($spacing, 'xs') 0;
-    color: map-get($colors, 'text-light');
-    font-family: map-get($fonts, 'mono');
-    font-size: map-get($font-sizes, 'sm');
+    padding: map.get($spacing, 'xs') 0;
+    color: map.get($colors, 'text-light');
+    font-family: map.get($fonts, 'mono');
+    font-size: map.get($font-sizes, 'sm');
     text-decoration: none;
     transition: color 0.3s ease;
     
     &::before {
       content: "0" counter(item) ".";
-      margin-right: map-get($spacing, 'xs');
-      color: map-get($colors, 'secondary');
+      margin-right: map.get($spacing, 'xs');
+      color: map.get($colors, 'secondary');
       font-size: 0.85em;
     }
     
     @include breakpoint('max', 'md') {
       width: 100%;
-      padding: map-get($spacing, 'md') 0;
-      font-size: map-get($font-sizes, 'lg');
+      padding: map.get($spacing, 'md') 0;
+      font-size: map.get($font-sizes, 'lg');
     }
     
     &:hover, &:focus, &.active {
-      color: map-get($colors, 'secondary');
+      color: map.get($colors, 'secondary');
       text-decoration: none;
     }
   }
   
   // Resume button
   &__resume-btn {
-    margin-left: map-get($spacing, 'lg');
+    margin-left: map.get($spacing, 'lg');
     
     @include breakpoint('max', 'md') {
-      margin: map-get($spacing, 'xl') 0 0;
+      margin: map.get($spacing, 'xl') 0 0;
       align-self: center;
     }
   }
@@ -160,10 +161,10 @@
     justify-content: center;
     align-items: center;
     position: relative;
-    z-index: map-get($z-index, 'modal') + 1;
+    z-index: map.get($z-index, 'modal') + 1;
     border: 0;
     background-color: transparent;
-    color: map-get($colors, 'secondary');
+    color: map.get($colors, 'secondary');
     width: 36px;
     height: 36px;
     padding: 0;
@@ -184,7 +185,7 @@
     position: relative;
     width: 24px;
     height: 2px;
-    background-color: map-get($colors, 'secondary');
+    background-color: map.get($colors, 'secondary');
     transition: background-color 0.3s ease;
     
     &::before, &::after {
@@ -193,7 +194,7 @@
       left: 0;
       width: 100%;
       height: 2px;
-      background-color: map-get($colors, 'secondary');
+      background-color: map.get($colors, 'secondary');
       transition-duration: 0.3s;
       transition-property: transform, top;
       transition-timing-function: ease;
@@ -230,9 +231,9 @@
     left: 0;
     width: 100vw;
     height: 100vh;
-    background-color: rgba(map-get($colors, 'bg'), 0.7);
+    background-color: rgba(map.get($colors, 'bg'), 0.7);
     backdrop-filter: blur(5px);
-    z-index: map-get($z-index, 'dropdown');
+    z-index: map.get($z-index, 'dropdown');
     visibility: hidden;
     opacity: 0;
     transition: visibility 0.3s ease, opacity 0.3s ease;

--- a/src/styles/components/_hero.scss
+++ b/src/styles/components/_hero.scss
@@ -1,13 +1,14 @@
 /* File: src/styles/components/_hero.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 .hero {
   min-height: calc(100vh - 80px); // Account for header height
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: map-get($spacing, '3xl') 0;
+  padding: map.get($spacing, '3xl') 0;
   position: relative;
   
   // Ensure minimum height on smaller screens
@@ -17,7 +18,7 @@
   
   // For larger screens, add extra top padding for better vertical centering
   @include breakpoint('xl') {
-    padding-top: map-get($spacing, '4xl');
+    padding-top: map.get($spacing, '4xl');
   }
   
   // Background decorative elements
@@ -34,7 +35,7 @@
     right: 0;
     width: 50%;
     height: 100%;
-    background-image: radial-gradient(rgba(map-get($colors, 'secondary'), 0.1) 1px, transparent 1px);
+    background-image: radial-gradient(rgba(map.get($colors, 'secondary'), 0.1) 1px, transparent 1px);
     background-size: 20px 20px;
     opacity: 0.2;
     z-index: -1;
@@ -53,9 +54,9 @@
   
   // Pre-title (small text above the main heading)
   &__pre-title {
-    font-family: map-get($fonts, 'mono');
-    color: map-get($colors, 'secondary');
-    margin-bottom: map-get($spacing, 'md');
+    font-family: map.get($fonts, 'mono');
+    color: map.get($colors, 'secondary');
+    margin-bottom: map.get($spacing, 'md');
     display: block;
     @include font-size('base');
     
@@ -68,9 +69,9 @@
   &__title {
     @include font-size('4xl');
     line-height: 1.1;
-    margin-bottom: map-get($spacing, 'sm');
-    font-weight: map-get($font-weights, 'bold');
-    color: map-get($colors, 'text-light');
+    margin-bottom: map.get($spacing, 'sm');
+    font-weight: map.get($font-weights, 'bold');
+    color: map.get($colors, 'text-light');
     
     @include breakpoint('md') {
       @include font-size('5xl');
@@ -82,9 +83,9 @@
     
     &--highlight {
       display: block;
-      color: rgba(map-get($colors, 'text-light'), 0.8);
+      color: rgba(map.get($colors, 'text-light'), 0.8);
       @include font-size('3xl');
-      margin-top: map-get($spacing, 'xs');
+      margin-top: map.get($spacing, 'xs');
       
       @include breakpoint('md') {
         @include font-size('4xl');
@@ -99,17 +100,17 @@
   // Description text
   &__description {
     max-width: 540px;
-    margin-top: map-get($spacing, 'lg');
-    margin-bottom: map-get($spacing, 'xl');
+    margin-top: map.get($spacing, 'lg');
+    margin-bottom: map.get($spacing, 'xl');
     @include font-size('lg');
-    color: map-get($colors, 'text');
+    color: map.get($colors, 'text');
     
     @include breakpoint('md') {
       @include font-size('xl');
     }
     
     p + p {
-      margin-top: map-get($spacing, 'md');
+      margin-top: map.get($spacing, 'md');
     }
   }
   
@@ -117,21 +118,21 @@
   &__cta {
     display: flex;
     flex-wrap: wrap;
-    gap: map-get($spacing, 'md');
-    margin-top: map-get($spacing, 'xl');
+    gap: map.get($spacing, 'md');
+    margin-top: map.get($spacing, 'xl');
   }
   
   // Scroll down indicator
   &__scroll-indicator {
     position: absolute;
-    bottom: map-get($spacing, 'xl');
+    bottom: map.get($spacing, 'xl');
     left: 50%;
     transform: translateX(-50%);
     display: flex;
     flex-direction: column;
     align-items: center;
-    color: map-get($colors, 'text');
-    font-family: map-get($fonts, 'mono');
+    color: map.get($colors, 'text');
+    font-family: map.get($fonts, 'mono');
     @include font-size('xs');
     transition: opacity 0.3s ease;
     
@@ -146,8 +147,8 @@
       display: block;
       width: 1px;
       height: 50px;
-      background-color: map-get($colors, 'secondary');
-      margin-top: map-get($spacing, 'sm');
+      background-color: map.get($colors, 'secondary');
+      margin-top: map.get($spacing, 'sm');
       animation: scrollDown 1.5s infinite;
     }
   }
@@ -155,7 +156,7 @@
   // Float effect for image
   &__image {
     position: relative;
-    border-radius: map-get($border-radius, 'md');
+    border-radius: map.get($border-radius, 'md');
     overflow: hidden;
     box-shadow: 0 20px 40px -20px rgba(0, 0, 0, 0.3);
     
@@ -166,8 +167,8 @@
       left: 0;
       right: 0;
       bottom: 0;
-      border: 2px solid map-get($colors, 'secondary');
-      border-radius: map-get($border-radius, 'md');
+      border: 2px solid map.get($colors, 'secondary');
+      border-radius: map.get($border-radius, 'md');
       z-index: -1;
       transition: transform 0.3s ease;
     }
@@ -180,7 +181,7 @@
       width: 100%;
       height: auto;
       display: block;
-      border-radius: map-get($border-radius, 'md');
+      border-radius: map.get($border-radius, 'md');
       position: relative;
       z-index: 1;
     }
@@ -191,7 +192,7 @@
     &__content {
       display: grid;
       grid-template-columns: 3fr 2fr;
-      gap: map-get($spacing, 'xl');
+      gap: map.get($spacing, 'xl');
       align-items: center;
     }
     
@@ -210,7 +211,7 @@
   // Mobile layout
   @include breakpoint('max', 'md') {
     &__media {
-      margin-top: map-get($spacing, 'xl');
+      margin-top: map.get($spacing, 'xl');
     }
   }
 }
@@ -235,7 +236,7 @@
 .circle-decoration {
   position: absolute;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(map-get($colors, 'secondary'), 0.2) 0%, rgba(map-get($colors, 'secondary'), 0) 70%);
+  background: radial-gradient(circle, rgba(map.get($colors, 'secondary'), 0.2) 0%, rgba(map.get($colors, 'secondary'), 0) 70%);
   filter: blur(60px);
   z-index: -1;
   opacity: 0.5;

--- a/src/styles/components/_responsive-demo.scss
+++ b/src/styles/components/_responsive-demo.scss
@@ -1,13 +1,14 @@
 /* File: src/styles/components/_responsive-demo.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 // Responsive card component
 .card {
   display: flex;
   flex-direction: column;
-  background-color: rgba(map-get($colors, 'bg-light'), 0.5);
-  border-radius: map-get($border-radius, 'lg');
+  background-color: rgba(map.get($colors, 'bg-light'), 0.5);
+  border-radius: map.get($border-radius, 'lg');
   overflow: hidden;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   
@@ -35,19 +36,19 @@
   
   // Card content
   &__content {
-    padding: map-get($spacing, 'lg');
+    padding: map.get($spacing, 'lg');
     flex: 1;
     
     @include breakpoint('md') {
-      padding: map-get($spacing, 'xl');
+      padding: map.get($spacing, 'xl');
     }
   }
   
   // Card title
   &__title {
     @include font-size('xl');
-    font-weight: map-get($font-weights, 'bold');
-    margin-bottom: map-get($spacing, 'sm');
+    font-weight: map.get($font-weights, 'bold');
+    margin-bottom: map.get($spacing, 'sm');
     @include color('text-light');
     
     @include breakpoint('md') {
@@ -58,26 +59,26 @@
   // Card description
   &__description {
     @include font-size('base');
-    margin-bottom: map-get($spacing, 'md');
+    margin-bottom: map.get($spacing, 'md');
   }
   
   // Card footer
   &__footer {
-    padding: map-get($spacing, 'md') map-get($spacing, 'lg');
-    border-top: 1px solid rgba(map-get($colors, 'text'), 0.1);
+    padding: map.get($spacing, 'md') map.get($spacing, 'lg');
+    border-top: 1px solid rgba(map.get($colors, 'text'), 0.1);
     display: flex;
     justify-content: space-between;
     align-items: center;
     
     @include breakpoint('md') {
-      padding: map-get($spacing, 'md') map-get($spacing, 'xl');
+      padding: map.get($spacing, 'md') map.get($spacing, 'xl');
     }
   }
   
   // Card actions
   &__actions {
     display: flex;
-    gap: map-get($spacing, 'sm');
+    gap: map.get($spacing, 'sm');
   }
   
   // Card variants
@@ -101,7 +102,7 @@
   }
   
   &--featured {
-    border: 1px solid rgba(map-get($colors, 'secondary'), 0.3);
+    border: 1px solid rgba(map.get($colors, 'secondary'), 0.3);
   }
 }
 
@@ -109,7 +110,7 @@
 .card-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: map-get($spacing, 'lg');
+  gap: map.get($spacing, 'lg');
   
   @include breakpoint('sm') {
     grid-template-columns: repeat(2, 1fr);

--- a/src/styles/utils/_responsive-media.scss
+++ b/src/styles/utils/_responsive-media.scss
@@ -1,6 +1,7 @@
 /* File: src/styles/utils/_responsive-media.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 // Image aspect ratio container
 .aspect-ratio {
@@ -153,7 +154,7 @@
 
 // Lazy loading image placeholder
 .lazy-placeholder {
-  background-color: rgba(map-get($colors, 'text'), 0.1);
+  background-color: rgba(map.get($colors, 'text'), 0.1);
   position: relative;
   overflow: hidden;
   

--- a/src/styles/utils/_responsive-spacing.scss
+++ b/src/styles/utils/_responsive-spacing.scss
@@ -1,6 +1,7 @@
 /* File: src/styles/utils/_responsive-spacing.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 // Generate responsive spacing utilities for all breakpoints
 @each $breakpoint, $breakpoint-value in $breakpoints {

--- a/src/styles/utils/_responsive-typography.scss
+++ b/src/styles/utils/_responsive-typography.scss
@@ -1,6 +1,7 @@
 /* File: src/styles/utils/_responsive-typography.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use '../base/responsive' as responsive;
 @use 'sass:map';
 
 // Responsive font size utilities
@@ -87,27 +88,27 @@
 
 // Fluid typography for headings
 h1 {
-  @include fluid-type(320px, 1200px, map.get($font-sizes, '3xl'), map.get($font-sizes, '6xl'));
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, '3xl'), map.get($font-sizes, '6xl'));
 }
 
 h2 {
-  @include fluid-type(320px, 1200px, map.get($font-sizes, '2xl'), map.get($font-sizes, '4xl'));
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, '2xl'), map.get($font-sizes, '4xl'));
 }
 
 h3 {
-  @include fluid-type(320px, 1200px, map.get($font-sizes, 'xl'), map.get($font-sizes, '3xl'));
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'xl'), map.get($font-sizes, '3xl'));
 }
 
 h4 {
-  @include fluid-type(320px, 1200px, map.get($font-sizes, 'lg'), map.get($font-sizes, '2xl'));
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'lg'), map.get($font-sizes, '2xl'));
 }
 
 h5 {
-  @include fluid-type(320px, 1200px, map.get($font-sizes, 'base'), map.get($font-sizes, 'xl'));
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'base'), map.get($font-sizes, 'xl'));
 }
 
 h6 {
-  @include fluid-type(320px, 1200px, map.get($font-sizes, 'sm'), map.get($font-sizes, 'lg'));
+  @include responsive.fluid-type(320px, 1200px, map.get($font-sizes, 'sm'), map.get($font-sizes, 'lg'));
 }
 
 // Line clamp utilities for text truncation

--- a/src/styles/utils/_responsive-typography.scss
+++ b/src/styles/utils/_responsive-typography.scss
@@ -1,6 +1,7 @@
 /* File: src/styles/utils/_responsive-typography.scss */
 @use '../base/variables' as *;
 @use '../base/mixins' as *;
+@use 'sass:map';
 
 // Responsive font size utilities
 @each $breakpoint, $breakpoint-value in $breakpoints {
@@ -86,27 +87,27 @@
 
 // Fluid typography for headings
 h1 {
-  @include fluid-type(320px, 1200px, map-get($font-sizes, '3xl'), map-get($font-sizes, '6xl'));
+  @include fluid-type(320px, 1200px, map.get($font-sizes, '3xl'), map.get($font-sizes, '6xl'));
 }
 
 h2 {
-  @include fluid-type(320px, 1200px, map-get($font-sizes, '2xl'), map-get($font-sizes, '4xl'));
+  @include fluid-type(320px, 1200px, map.get($font-sizes, '2xl'), map.get($font-sizes, '4xl'));
 }
 
 h3 {
-  @include fluid-type(320px, 1200px, map-get($font-sizes, 'xl'), map-get($font-sizes, '3xl'));
+  @include fluid-type(320px, 1200px, map.get($font-sizes, 'xl'), map.get($font-sizes, '3xl'));
 }
 
 h4 {
-  @include fluid-type(320px, 1200px, map-get($font-sizes, 'lg'), map-get($font-sizes, '2xl'));
+  @include fluid-type(320px, 1200px, map.get($font-sizes, 'lg'), map.get($font-sizes, '2xl'));
 }
 
 h5 {
-  @include fluid-type(320px, 1200px, map-get($font-sizes, 'base'), map-get($font-sizes, 'xl'));
+  @include fluid-type(320px, 1200px, map.get($font-sizes, 'base'), map.get($font-sizes, 'xl'));
 }
 
 h6 {
-  @include fluid-type(320px, 1200px, map-get($font-sizes, 'sm'), map-get($font-sizes, 'lg'));
+  @include fluid-type(320px, 1200px, map.get($font-sizes, 'sm'), map.get($font-sizes, 'lg'));
 }
 
 // Line clamp utilities for text truncation


### PR DESCRIPTION
This PR resolves SASS compilation errors and updates our styling system to use the modern SASS module approach.

## Changes

- Rename the '2xl' breakpoint to 'xxl' to avoid SASS errors with numeric identifiers
- Update all SCSS files to use the SASS module system (`@use 'sass:map'`, `@use 'sass:math'`)
- Fix issues with the `fluid-type` mixin by properly importing it across files
- Update percentage calculations to use modern `math.div` and `math.percentage` functions
- Remove problematic functions and simplified visibility utilities
- Ensure proper imports and namespacing across SCSS modules

## Testing

These changes have been tested locally and resolve all compilation errors. The website now renders correctly in the local development server.

## Why

Modern SASS has deprecated several global functions and now encourages using its module system. These changes ensure our codebase follows best practices and eliminates numerous deprecation warnings and compilation errors.